### PR TITLE
Fixes infinite recursion and handles inherited types

### DIFF
--- a/lib/client/getTypes.js
+++ b/lib/client/getTypes.js
@@ -144,7 +144,10 @@ module.exports = function(env, c) {
 			op[name] = function() {
 				_.forEach(type.prop, function(v, k) {
 					if (_.has(types, v)) {
-						types[name].prop[k] = op[v]();
+						// Prevents infinite recursion loop, if child is of same type
+						if (v !== name) {
+							types[name].prop[k] = op[v]();
+						}
 					}
 					else if (typeof(v) === 'function') {
 						types[name].prop[k] = v();

--- a/lib/client/method.js
+++ b/lib/client/method.js
@@ -36,7 +36,23 @@ module.exports = function(env, c) {
 				'xsi:type': defType
 			};
 		}
-		
+
+		// Adding this to handle the inherited types
+		// Applies to only fields that are not in 'def'
+		_.forEach(obj, function(v, k) {
+			if (!_.has(def, k)) {
+				if (Array.isArray(v)) {
+					a[k] = _.map(v, function(o) {
+						return getFields(v, o);
+					});
+				}	else if (_.isObject(v)) {
+					a[k] = getFields(v, obj[k]);
+				}	else {
+					a[k] = v;
+				}
+			}
+		});
+
 		// loop through each field in the type definition and look for fields
 		// that were supplied by the user
 		_.forEach(def, function(v, k) {


### PR DESCRIPTION
- Fixes infinite recursion in creating type functions, when
  child is of same type as parent
- Handles inherited fields in getFields within method call for
  types that include inherited fields
  E.g.,
  - type VirtualCdrom has zero properties by itself
  - its parent VirtualDevice has several properties that VirtualCdrom inherits